### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "Catalyst,Symbolics"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,41 @@
+using MomentClosure, BenchmarkTools
+using Catalyst, Symbolics
+
+const SUITE = BenchmarkGroup()
+
+rn = @reaction_network begin
+    (c₁ / Ω^2), 2X + Y → 3X
+    (c₂), X → Y
+    (Ω * c₃, c₄), 0 ↔ X
+end
+
+# =============================================================================
+# Moment equation generation
+# =============================================================================
+
+SUITE["generate"] = BenchmarkGroup()
+
+SUITE["generate"]["central_2"] = @benchmarkable generate_central_moment_eqs(
+    $rn, 2; combinatoric_ratelaws = false
+)
+SUITE["generate"]["central_2_4"] = @benchmarkable generate_central_moment_eqs(
+    $rn, 2, 4; combinatoric_ratelaws = false
+)
+SUITE["generate"]["raw_2"] = @benchmarkable generate_raw_moment_eqs(
+    $rn, 2; combinatoric_ratelaws = false
+)
+SUITE["generate"]["raw_3"] = @benchmarkable generate_raw_moment_eqs(
+    $rn, 3; combinatoric_ratelaws = false
+)
+
+# =============================================================================
+# Moment closure
+# =============================================================================
+
+sys = generate_central_moment_eqs(rn, 2, 4; combinatoric_ratelaws = false)
+raw_sys = generate_raw_moment_eqs(rn, 2; combinatoric_ratelaws = false)
+
+SUITE["closure"] = BenchmarkGroup()
+
+SUITE["closure"]["zero_central"] = @benchmarkable moment_closure($sys, "zero")
+SUITE["closure"]["normal_raw"] = @benchmarkable moment_closure($raw_sys, "normal")


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~54s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~54s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md